### PR TITLE
Switch to `RUFF_OUTPUT_FORMAT`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
           python3 $GITHUB_ACTION_PATH/action/main.py
         fi
       env:
-        RUFF_FORMAT: github
+        RUFF_OUTPUT_FORMAT: github
         INPUT_ARGS: ${{ inputs.args }}
         INPUT_SRC: ${{ inputs.src }}
         INPUT_VERSION: ${{ inputs.version }}


### PR DESCRIPTION
`RUFF_FORMAT` was deprecated in favor of `RUFF_OUTPUT_FORMAT` in  v0.0.291.

As far as I can tell, https://github.com/astral-sh/ruff/commit/bb4f7c681a57f1a0b752fd767c1c75e1fbf878fb#diff-f65bcd73f3a1cda3b14acd953f697a2ffa2f28507a7471b48b4dc6366f5bd791R183-R190 will keep triggering the warning if `RUFF_FORMAT` is still present. Considering that `ruff` is now at v0.1.x I hope _not_ setting the previous variable is acceptable.

resolves https://github.com/ChartBoost/ruff-action/issues/6