### PR TITLE
Provide support to lint/format changed files only

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,10 @@ See [Configuring Ruff](https://github.com/astral-sh/ruff/blob/main/docs/configur
   with:
     args: 'format --check'
 ```
+
+### Only run ruff on changed files
+```yaml
+- uses: chartboost/ruff-action@v1
+  with:
+    changed-files: 'true'
+```

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,8 @@ runs:
       id: changed-files
       if: ${{ inputs.changed-files == 'true' }}
       uses: tj-actions/changed-files@v44
+      with:
+        files: '**.py'
     - run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
           python $GITHUB_ACTION_PATH/action/main.py

--- a/action.yml
+++ b/action.yml
@@ -16,12 +16,20 @@ inputs:
     description: 'The version of ruff to use, e.g. "0.0.259"'
     required: false
     default: ""
+  changed-files:
+    description: 'Whether to only run ruff on changed files. Default: false'
+    required: false
+    default: "false"
 branding:
   color: "black"
   icon: "code"
 runs:
   using: composite
   steps:
+    - name: Get changed files
+      id: changed-files
+      if: ${{ inputs.changed-files == 'true' }}
+      uses: tj-actions/changed-files@v44
     - run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
           python $GITHUB_ACTION_PATH/action/main.py
@@ -33,5 +41,6 @@ runs:
         INPUT_ARGS: ${{ inputs.args }}
         INPUT_SRC: ${{ inputs.src }}
         INPUT_VERSION: ${{ inputs.version }}
+        CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         pythonioencoding: utf-8
       shell: bash

--- a/action/main.py
+++ b/action/main.py
@@ -24,8 +24,9 @@ req = f"ruff{version_specifier}"
 
 # If CHANGED_FILES is not empty, split it into a list; otherwise, use SRC
 files_to_check = shlex.split(CHANGED_FILES or SRC)
+# Exclude non-Python files
+files_to_check = [f for f in files_to_check if f.endswith(".py")]
 
 proc = run(["pipx", "run", req, *shlex.split(ARGS), *files_to_check])
-# proc = run(["pipx", "run", req, *shlex.split(ARGS), *shlex.split(SRC)])
 
 sys.exit(proc.returncode)

--- a/action/main.py
+++ b/action/main.py
@@ -11,6 +11,7 @@ ACTION_PATH = Path(os.environ["GITHUB_ACTION_PATH"])
 ARGS = os.getenv("INPUT_ARGS", default="")
 SRC = os.getenv("INPUT_SRC", default="")
 VERSION = os.getenv("INPUT_VERSION", default="")
+CHANGED_FILES = os.getenv("CHANGED_FILES", "")
 
 version_specifier = ""
 if VERSION != "":
@@ -21,6 +22,10 @@ if VERSION != "":
 
 req = f"ruff{version_specifier}"
 
-proc = run(["pipx", "run", req, *shlex.split(ARGS), *shlex.split(SRC)])
+# If CHANGED_FILES is not empty, split it into a list; otherwise, use SRC
+files_to_check = shlex.split(CHANGED_FILES or SRC)
+
+proc = run(["pipx", "run", req, *shlex.split(ARGS), *files_to_check])
+# proc = run(["pipx", "run", req, *shlex.split(ARGS), *shlex.split(SRC)])
 
 sys.exit(proc.returncode)

--- a/action/main.py
+++ b/action/main.py
@@ -24,8 +24,6 @@ req = f"ruff{version_specifier}"
 
 # If CHANGED_FILES is not empty, split it into a list; otherwise, use SRC
 files_to_check = shlex.split(CHANGED_FILES or SRC)
-# Exclude non-Python files
-files_to_check = [f for f in files_to_check if f.endswith(".py")]
 
 proc = run(["pipx", "run", req, *shlex.split(ARGS), *files_to_check])
 


### PR DESCRIPTION
Closes #21 

This PR adds support for the action to only operate on the files that have been changed, either in a PR or a single push (for both these cases, it should work). To enable this feature, `changed-files` needs to be set to `"true"`. We can rename the keyword if that's too generic/vague.