### PR TITLE
Fix changed-files for cases where no python files changed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,7 @@ runs:
         INPUT_ARGS: ${{ inputs.args }}
         INPUT_SRC: ${{ inputs.src }}
         INPUT_VERSION: ${{ inputs.version }}
+        IS_CHANGED_FILES_ENABLED: ${{ inputs.changed-files }}
         CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         pythonioencoding: utf-8
       shell: bash

--- a/action/main.py
+++ b/action/main.py
@@ -28,7 +28,7 @@ files_to_check = shlex.split(CHANGED_FILES or SRC)
 
 # If IS_CHANGED_FILES_ENABLED is true and CHANGED_FILES was empty, there were no files to check
 # Short circuit to prevent ruff from running on all files
-if IS_CHANGED_FILES_ENABLED is "true" and not CHANGED_FILES:
+if IS_CHANGED_FILES_ENABLED == "true" and not CHANGED_FILES:
     sys.exit(0)
     
 proc = run(["pipx", "run", req, *shlex.split(ARGS), *files_to_check])

--- a/action/main.py
+++ b/action/main.py
@@ -12,6 +12,7 @@ ARGS = os.getenv("INPUT_ARGS", default="")
 SRC = os.getenv("INPUT_SRC", default="")
 VERSION = os.getenv("INPUT_VERSION", default="")
 CHANGED_FILES = os.getenv("CHANGED_FILES", "")
+IS_CHANGED_FILES_ENABLED = os.getenv("IS_CHANGED_FILES_ENABLED", default="false")
 
 version_specifier = ""
 if VERSION != "":
@@ -25,6 +26,11 @@ req = f"ruff{version_specifier}"
 # If CHANGED_FILES is not empty, split it into a list; otherwise, use SRC
 files_to_check = shlex.split(CHANGED_FILES or SRC)
 
+# If IS_CHANGED_FILES_ENABLED is true and CHANGED_FILES was empty, there were no files to check
+# Short circuit to prevent ruff from running on all files
+if IS_CHANGED_FILES_ENABLED is "true" and not CHANGED_FILES:
+    sys.exit(0)
+    
 proc = run(["pipx", "run", req, *shlex.split(ARGS), *files_to_check])
 
 sys.exit(proc.returncode)


### PR DESCRIPTION
## Problem

When a PR contains no changed python files, but `changed-files` is set to true, ruff will run on all files, including ones not changed.

## Solution

Pass the input through to the script and short circuit to success in cases where both the flag is set and no python files were changed.