### PR TITLE
GitHub Actions: Use ruff format instead of psf/black

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,6 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: psf/black@stable
       - uses: chartboost/ruff-action@v1
+        with:
+          args: 'check'
+      - uses: chartboost/ruff-action@v1
+        with:
+          args: 'format'
       - uses: jakebailey/pyright-action@v2


### PR DESCRIPTION
```diff
-      - uses: psf/black@stable
+      - uses: chartboost/ruff-action@v1
+        with:
+          args: 'format'
```