### PR TITLE
Add warning + redirect to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> [!WARNING]  
+> This repository is no longer actively maintained. It is strongly suggested that you use the [officially-supported ruff action from Astral](https://github.com/astral-sh/ruff-action).
+
+
 # ruff-action
 A GitHub Action for Ruff
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!WARNING]  
-> This repository is no longer actively maintained. It is strongly suggested that you use the [officially-supported ruff action from Astral](https://github.com/astral-sh/ruff-action).
+> This repository is no longer actively maintained. It is strongly suggested that you use the [officially-supported Ruff action from Astral](https://github.com/astral-sh/ruff-action).
 
 
 # ruff-action


### PR DESCRIPTION
Per discussion with @CB-GuangyaoXie, @brucearctor and @charliermarsh in #26 and https://github.com/astral-sh/ruff-action/issues/10 I'm adding a note to indicate that this codebase is no longer actively maintained and direct users to the new github action which is maintained.

IMO, this closes #26 and closes https://github.com/astral-sh/ruff-action/issues/10

It might also be nice for this repo to be archived to give users a more significant warning, but I think thats up to you @CB-GuangyaoXie 